### PR TITLE
Removed extra unessecary check when migrating

### DIFF
--- a/xormigrate.go
+++ b/xormigrate.go
@@ -93,9 +93,6 @@ func (x *Xormigrate) InitSchema(initSchema InitSchemaFunc) {
 
 // Migrate executes all migrations that did not run yet.
 func (x *Xormigrate) Migrate() error {
-	if !x.hasMigrations() {
-		return ErrNoMigrationDefined
-	}
 	return x.migrate("")
 }
 


### PR DESCRIPTION
The only thing `Migrate()` does is calling `migrate()` which also runs the same check first thing when it's called. So no need to call it twice.