### PR TITLE
Add Migration descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,12 +142,14 @@ m := xormigrate.New(db, []*xormigrate.Migration{
 })
 
 // Don't log anything
-m.SetLogger(nil) 
+m.SetLogger(m.NilLogger()) 
 
 // This is the default logging format
-// xormigrate: message
-logger := log.New(os.Stdout, "xormigrate: ", 0)
-m.SetLogger(logger)
+// [xormigrate] message
+m.SetLogger(m.DefaultLogger())
+
+// Or, pass in any io.Writer you want
+m.SetLogger(m.NewLogger(os.Stdout))
 ```
 
 ## Credits

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ func main() {
 		{
 			ID: "201608301400",
 			// An optional description to print out to the Xormigrate logger
-			Desc: "Create the Person table",
+			Description: "Create the Person table",
 			Migrate: func(tx *xorm.Engine) error {
 				// it's a good pratice to copy the struct inside the function,
 				// so side effects are prevented if the original struct changes during the time

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ func main() {
 		// create persons table
 		{
 			ID: "201608301400",
+			// An optional description to print out to the Xormigrate logger
+			Desc: "Create the Person table",
 			Migrate: func(tx *xorm.Engine) error {
 				// it's a good pratice to copy the struct inside the function,
 				// so side effects are prevented if the original struct changes during the time
@@ -130,6 +132,22 @@ m.InitSchema(func(tx *xorm.Engine) error {
 	}
 	return nil
 })
+```
+
+## Adding migration descriptions to your logging
+Xormigrate's logger defaults to stdout, but it can be changed to suit your needs.  
+```go
+m := xormigrate.New(db, []*xormigrate.Migration{
+    // your migrations here
+})
+
+// Don't log anything
+m.SetLogger(nil) 
+
+// This is the default logging format
+// xormigrate: message
+logger := log.New(os.Stdout, "xormigrate: ", 0)
+m.SetLogger(logger)
 ```
 
 ## Credits

--- a/README.md
+++ b/README.md
@@ -142,14 +142,15 @@ m := xormigrate.New(db, []*xormigrate.Migration{
 })
 
 // Don't log anything
-m.SetLogger(m.NilLogger()) 
+m.NilLogger() 
 
-// This is the default logging format
+// This is the default logger
+// No need to initialize this unless it was changed
 // [xormigrate] message
-m.SetLogger(m.DefaultLogger())
+m.DefaultLogger()
 
-// Or, pass in any io.Writer you want
-m.SetLogger(m.NewLogger(os.Stdout))
+// Or, create a logger with any io.Writer you want
+m.NewLogger(os.Stdout)
 ```
 
 ## Credits

--- a/logger.go
+++ b/logger.go
@@ -1,0 +1,17 @@
+package xormigrate
+
+import (
+	"io/ioutil"
+	"log"
+	"os"
+)
+
+var logger = log.New(os.Stdout, "xormigrate: ", 0)
+
+func (x *Xormigrate) SetLogger(l *log.Logger) {
+	if l != nil {
+		logger = l
+	} else {
+		logger = log.New(ioutil.Discard, "", 0)
+	}
+}

--- a/logger.go
+++ b/logger.go
@@ -27,11 +27,6 @@ func (x *Xormigrate) SetLogger(l LoggerInterface) {
 	logger = l
 }
 
-// NewLogger returns a Xormigrate logger with a specified io.Writer
-func NewLogger(writer io.Writer) *XormigrateLogger {
-	return &XormigrateLogger{log.New(writer, "", 0)}
-}
-
 func defaultLogger() *XormigrateLogger {
 	return &XormigrateLogger{log.New(os.Stdout, "[xormigrate] ", 0)}
 }
@@ -45,6 +40,11 @@ func (x *Xormigrate) DefaultLogger() {
 // NilLogger sets a Xormigrate logger that discards all messages
 func (x *Xormigrate) NilLogger() {
 	x.SetLogger(&XormigrateLogger{log.New(ioutil.Discard, "", 0)})
+}
+
+// NewLogger sets a Xormigrate logger with a specified io.Writer
+func (x *Xormigrate) NewLogger(writer io.Writer) {
+	x.SetLogger(&XormigrateLogger{log.New(writer, "", 0)})
 }
 
 type XormigrateLogger struct {

--- a/logger.go
+++ b/logger.go
@@ -1,17 +1,92 @@
 package xormigrate
 
 import (
+	"io"
 	"io/ioutil"
 	"log"
 	"os"
 )
 
-var logger = log.New(os.Stdout, "xormigrate: ", 0)
+type LoggerInterface interface {
+	Debug(v ...interface{})
+	Debugf(format string, v ...interface{})
+	Info(v ...interface{})
+	Infof(format string, v ...interface{})
+	Warn(v ...interface{})
+	Warnf(format string, v ...interface{})
+	Error(v ...interface{})
+	Errorf(format string, v ...interface{})
+}
 
-func (x *Xormigrate) SetLogger(l *log.Logger) {
-	if l != nil {
-		logger = l
-	} else {
-		logger = log.New(ioutil.Discard, "", 0)
-	}
+var (
+	logger LoggerInterface = defaultLogger()
+)
+
+// SetLogger sets the Xormigrate logger
+func (x *Xormigrate) SetLogger(l LoggerInterface) {
+	logger = l
+}
+
+// NewLogger returns a Xormigrate logger with a specified io.Writer
+func NewLogger(writer io.Writer) *XormigrateLogger {
+	return &XormigrateLogger{log.New(writer, "", 0)}
+}
+
+func defaultLogger() *XormigrateLogger {
+	return &XormigrateLogger{log.New(os.Stdout, "[xormigrate] ", 0)}
+}
+
+// DefaultLogger sets a Xormigrate logger with default settings
+// e.g. "[xormigrate] message"
+func (x *Xormigrate) DefaultLogger() {
+	x.SetLogger(defaultLogger())
+}
+
+// NilLogger sets a Xormigrate logger that discards all messages
+func (x *Xormigrate) NilLogger() {
+	x.SetLogger(&XormigrateLogger{log.New(ioutil.Discard, "", 0)})
+}
+
+type XormigrateLogger struct {
+	*log.Logger
+}
+
+// Debug prints a Debug message
+func (l *XormigrateLogger) Debug(v ...interface{}) {
+	l.Logger.Print(v...)
+}
+
+// Debugf prints a formatted Debug message
+func (l *XormigrateLogger) Debugf(format string, v ...interface{}) {
+	l.Logger.Printf(format, v...)
+}
+
+// Info prints an Info message
+func (l *XormigrateLogger) Info(v ...interface{}) {
+	l.Logger.Print(v...)
+}
+
+// Infof prints a formatted Info message
+func (l *XormigrateLogger) Infof(format string, v ...interface{}) {
+	l.Logger.Printf(format, v...)
+}
+
+// Warn prints a Warning message
+func (l *XormigrateLogger) Warn(v ...interface{}) {
+	l.Logger.Print(v...)
+}
+
+// Warnf prints a formatted Warning message
+func (l *XormigrateLogger) Warnf(format string, v ...interface{}) {
+	l.Logger.Printf(format, v...)
+}
+
+// Error prints an Error message
+func (l *XormigrateLogger) Error(v ...interface{}) {
+	l.Logger.Print(v...)
+}
+
+// Errorf prints a formatted Error message
+func (l *XormigrateLogger) Errorf(format string, v ...interface{}) {
+	l.Logger.Printf(format, v...)
 }

--- a/xormigrate.go
+++ b/xormigrate.go
@@ -24,6 +24,8 @@ type InitSchemaFunc func(*xorm.Engine) error
 type Migration struct {
 	// ID is the migration identifier. Usually a timestamp like "201601021504".
 	ID string `xorm:"id"`
+	// Desc is the migration description, which is optionally printed out when the migration is ran.
+	Desc string
 	// Migrate is a function that will br executed while running this migration.
 	Migrate MigrateFunc `xorm:"-"`
 	// Rollback will be executed on rollback. Can be nil.
@@ -266,6 +268,9 @@ func (x *Xormigrate) runMigration(migration *Migration) error {
 	}
 
 	if !x.migrationDidRun(migration) {
+		if len(migration.Desc) > 0 {
+			logger.Println(migration.Desc)
+		}
 		if err := migration.Migrate(x.db); err != nil {
 			return err
 		}

--- a/xormigrate_test.go
+++ b/xormigrate_test.go
@@ -18,8 +18,8 @@ type database struct {
 
 var migrations = []*Migration{
 	{
-		ID:   "201608301400",
-		Desc: "Add Person",
+		ID:          "201608301400",
+		Description: "Add Person",
 		Migrate: func(tx *xorm.Engine) error {
 			return tx.Sync2(&Person{})
 		},
@@ -66,7 +66,6 @@ type Book struct {
 func TestMigration(t *testing.T) {
 	forEachDatabase(t, func(db *xorm.Engine) {
 		m := New(db, migrations)
-		m.SetLogger(nil)
 
 		err := m.Migrate()
 		assert.NoError(t, err)

--- a/xormigrate_test.go
+++ b/xormigrate_test.go
@@ -18,7 +18,8 @@ type database struct {
 
 var migrations = []*Migration{
 	{
-		ID: "201608301400",
+		ID:   "201608301400",
+		Desc: "Add Person",
 		Migrate: func(tx *xorm.Engine) error {
 			return tx.Sync2(&Person{})
 		},
@@ -65,6 +66,7 @@ type Book struct {
 func TestMigration(t *testing.T) {
 	forEachDatabase(t, func(db *xorm.Engine) {
 		m := New(db, migrations)
+		m.SetLogger(nil)
 
 		err := m.Migrate()
 		assert.NoError(t, err)


### PR DESCRIPTION
One thing I really like about the Gitea migrations (as example) is that the "name/description" of the migration is printed when the migration occurs and thought it would make a nice feature for this as well.  
Rather than print to `fmt.Println` I figured a logger would be better so people can pipe the output wherever they want. (Or disable it if they don't care)

I am not sure what the "best" way to implement a logger is, so please correct as needed.