### PR TITLE
Return failed migration id if a migration failed

### DIFF
--- a/xormigrate.go
+++ b/xormigrate.go
@@ -129,7 +129,7 @@ func (x *Xormigrate) migrate(migrationID string) error {
 
 	for _, migration := range x.migrations {
 		if err := x.runMigration(migration); err != nil {
-			return err
+			return fmt.Errorf("migration %s failed: %s", migration.ID, err.Error())
 		}
 		if migrationID != "" && migration.ID == migrationID {
 			break

--- a/xormigrate.go
+++ b/xormigrate.go
@@ -129,7 +129,7 @@ func (x *Xormigrate) migrate(migrationID string) error {
 
 	for _, migration := range x.migrations {
 		if err := x.runMigration(migration); err != nil {
-			return fmt.Errorf("migration %s failed: %s", migration.ID, err.Error())
+			return err
 		}
 		if migrationID != "" && migration.ID == migrationID {
 			break
@@ -275,11 +275,11 @@ func (x *Xormigrate) runMigration(migration *Migration) error {
 			logger.Info(migration.Description)
 		}
 		if err := migration.Migrate(x.db); err != nil {
-			return err
+			return fmt.Errorf("migration %s failed: %s", migration.ID, err.Error())
 		}
 
 		if err := x.insertMigration(migration.ID); err != nil {
-			return err
+			return fmt.Errorf("inserting migration %s failed: %s", migration.ID, err.Error())
 		}
 	}
 	return nil


### PR DESCRIPTION
The id of a migration is currently not returned if it fails, which makes it harder to track down a bad migration. This PR modifies the returned error to include the migration id.