### PR TITLE
Log if long migration is skipped

### DIFF
--- a/xormigrate.go
+++ b/xormigrate.go
@@ -152,6 +152,7 @@ func (x *Xormigrate) migrate(migrationID string) error {
 
 	for _, migration := range x.migrations {
 		if migration.Long && !x.allowLong {
+			logger.Debugf("skipping migration %s: long migrations are disabled", migration.ID)
 			continue
 		}
 		if err := x.runMigration(migration); err != nil {


### PR DESCRIPTION
Just adding a simple debug log statement (I don't need these changes right now, if you don't want to create a new release, this can also go into the next one).